### PR TITLE
fix test-invoke-pip.yml

### DIFF
--- a/.github/workflows/test-invoke-pip.yml
+++ b/.github/workflows/test-invoke-pip.yml
@@ -8,10 +8,11 @@ on:
       - 'ready_for_review'
       - 'opened'
       - 'synchronize'
+  workflow_dispatch:
 
 concurrency:
-   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-   cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   matrix:
@@ -27,9 +28,10 @@ jobs:
           - linux-rocm-5_2
           - linux-cpu
           - macos-default
+          # - macos-nightly
           - windows-cpu
-          - windows-cuda-11_6
-          - windows-cuda-11_7
+          # - windows-cuda-11_6
+          # - windows-cuda-11_7
         include:
           - pytorch: linux-cuda-11_6
             os: ubuntu-22.04
@@ -49,40 +51,31 @@ jobs:
           - pytorch: macos-default
             os: macOS-12
             github-env: $GITHUB_ENV
+          # - pytorch: macos-nightly
+          #   os: macOS-12
+          #   github-env: $GITHUB_ENV
+          #   extra-index-url: 'https://download.pytorch.org/whl/nightly/cpu'
+          #   extra-argument: '--pre'
           - pytorch: windows-cpu
             os: windows-2022
             github-env: $env:GITHUB_ENV
-          - pytorch: windows-cuda-11_6
-            os: windows-2022
-            extra-index-url: 'https://download.pytorch.org/whl/cu116'
-            github-env: $env:GITHUB_ENV
-          - pytorch: windows-cuda-11_7
-            os: windows-2022
-            extra-index-url: 'https://download.pytorch.org/whl/cu117'
-            github-env: $env:GITHUB_ENV
+          # - pytorch: windows-cuda-11_6
+          #   os: windows-2022
+          #   extra-index-url: 'https://download.pytorch.org/whl/cu116'
+          #   github-env: $env:GITHUB_ENV
+          # - pytorch: windows-cuda-11_7
+          #   os: windows-2022
+          #   extra-index-url: 'https://download.pytorch.org/whl/cu117'
+          #   github-env: $env:GITHUB_ENV
+      fail-fast: false
     name: ${{ matrix.pytorch }} on ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    env:
+      PIP_USE_PEP517: '1'
     steps:
       - name: Checkout sources
         id: checkout-sources
         uses: actions/checkout@v3
-
-      - name: setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set Cache-Directory Windows
-        if: runner.os == 'Windows'
-        id: set-cache-dir-windows
-        run: |
-          echo "CACHE_DIR=$HOME\invokeai\models" >> ${{ matrix.github-env }}
-          echo "PIP_NO_CACHE_DIR=1" >> ${{ matrix.github-env }}
-
-      - name: Set Cache-Directory others
-        if: runner.os != 'Windows'
-        id: set-cache-dir-others
-        run: echo "CACHE_DIR=$HOME/invokeai/models" >> ${{ matrix.github-env }}
 
       - name: set test prompt to main branch validation
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -92,35 +85,57 @@ jobs:
         if: ${{ github.ref != 'refs/heads/main' }}
         run: echo "TEST_PROMPTS=tests/validate_pr_prompt.txt" >> ${{ matrix.github-env }}
 
+      - name: setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
       - name: install invokeai
-        run: pip3 install --use-pep517 -e .
         env:
           PIP_EXTRA_INDEX_URL: ${{ matrix.extra-index-url }}
+        run: >
+           pip3 install
+           -e ".[test]"
+           ${{ matrix.extra-argument }}
 
-      - name: Use Cached models
-        id: cache-sd-model
+      - name: run unit-tests
+        id: unit-tests
+        run: pytest
+
+      - name: set INVOKEAI_OUTDIR
+        run: >
+          python -c
+          "import os;from ldm.invoke.globals import Globals;OUTDIR=os.path.join(Globals.root,str('outputs'));print(f'INVOKEAI_OUTDIR={OUTDIR}')"
+          >> ${{ matrix.github-env }}
+
+      - name: set huggingface-cache dir
+        run: >
+          python -c
+          "from ldm.invoke.globals import global_models_dir;print(f'MODELS_CACHE_DIR={global_models_dir()}')"
+          >> ${{ matrix.github-env }}
+
+      - name: huggingface cache
+        id: huggingface-cache
         uses: actions/cache@v3
-        env:
-          cache-name: huggingface-models
         with:
-          path: ${{ env.CACHE_DIR }}
-          key: ${{ env.cache-name }}
+          path: ${{ env.MODELS_CACHE_DIR }}
+          key: huggingface-models
+          restore-keys: huggingface-models
           enableCrossOsArchive: true
 
       - name: run configure_invokeai
-        id: run-preload-models
+        id: run-configure-invokeai
         env:
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
         run: >
           configure_invokeai
           --yes
           --default_only
-          --full-precision
-        # can't use fp16 weights without a GPU
 
-      - name: Run the tests
-        if: runner.os != 'Windows'
-        id: run-tests
+      - name: run invoke
+        id: run-invoke
         env:
           # Set offline mode to make sure configure preloaded successfully.
           HF_HUB_OFFLINE: 1
@@ -131,10 +146,11 @@ jobs:
           --no-patchmatch
           --no-nsfw_checker
           --from_file ${{ env.TEST_PROMPTS }}
+          --outdir ${{ env.INVOKEAI_OUTDIR }}/${{ matrix.python-version }}/${{ matrix.pytorch }}
 
       - name: Archive results
         id: archive-results
         uses: actions/upload-artifact@v3
         with:
-          name: results_${{ matrix.pytorch }}_${{ matrix.python-version }}
-          path: ${{ env.INVOKEAI_ROOT }}/outputs
+          name: results
+          path: ${{ env.INVOKEAI_OUTDIR }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ models/ldm/stable-diffusion-v1/model.ckpt
 
 # ignore user models config
 configs/models.user.yaml
-config/models.user.yml
+configs/models.user.yml
+configs/models.yaml.orig
 invokeai.init
 
 # ignore the Anaconda/Miniconda installer used while building Docker image
@@ -72,6 +73,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+junit/
 
 # Translations
 *.mo

--- a/ldm/invoke/model_manager.py
+++ b/ldm/invoke/model_manager.py
@@ -923,7 +923,7 @@ class ModelManager(object):
     def _has_cuda(self) -> bool:
         return self.device.type == 'cuda'
 
-    def _diffuser_sha256(self,name_or_path:Union[str, Path])->Union[str,bytes]:
+    def _diffuser_sha256(self,name_or_path:Union[str, Path],chunksize=4096)->Union[str,bytes]:
         path = None
         if isinstance(name_or_path,Path):
            path = name_or_path
@@ -945,7 +945,8 @@ class ModelManager(object):
             for name in files:
                 count += 1
                 with open(os.path.join(root,name),'rb') as f:
-                    sha.update(f.read())
+                    while chunk := f.read(chunksize):
+                        sha.update(chunk)
         hash = sha.hexdigest()
         toc = time.time()
         print(f'  | sha256 = {hash} ({count} files hashed in','%4.2fs)' % (toc - tic))

--- a/tests/test_prompt_parser.py
+++ b/tests/test_prompt_parser.py
@@ -449,37 +449,37 @@ class PromptParserTestCase(unittest.TestCase):
         self.assertEqual(Blend([FlattenedPrompt([('mountain man', 1)]),
                                 FlattenedPrompt([('man mountain', 1)])],
                                 weights=[0.5,0.5]),
-                         pp.parse_legacy_blend('mountain man:1 man mountain:1'))
+                         pp.parse_legacy_blend('mountain man:1 man mountain:1', skip_normalize=False))
 
         self.assertEqual(Blend([FlattenedPrompt([('mountain', 1.1), ('man', 1)]),
                                 FlattenedPrompt([('man', 1), ('mountain', 0.9)])],
                                 weights=[0.5,0.5]),
-                         pp.parse_legacy_blend('mountain+ man:1 man mountain-:1'))
+                         pp.parse_legacy_blend('mountain+ man:1 man mountain-:1', skip_normalize=False))
 
         self.assertEqual(Blend([FlattenedPrompt([('mountain', 1.1), ('man', 1)]),
                                 FlattenedPrompt([('man', 1), ('mountain', 0.9)])],
                                 weights=[0.5,0.5]),
-                         pp.parse_legacy_blend('mountain+ man:1 man mountain-'))
+                         pp.parse_legacy_blend('mountain+ man:1 man mountain-', skip_normalize=False))
 
         self.assertEqual(Blend([FlattenedPrompt([('mountain', 1.1), ('man', 1)]),
                                 FlattenedPrompt([('man', 1), ('mountain', 0.9)])],
                                 weights=[0.5,0.5]),
-                         pp.parse_legacy_blend('mountain+ man: man mountain-:'))
+                         pp.parse_legacy_blend('mountain+ man: man mountain-:', skip_normalize=False))
 
         self.assertEqual(Blend([FlattenedPrompt([('mountain man', 1)]),
                                 FlattenedPrompt([('man mountain', 1)])],
                                 weights=[0.75,0.25]),
-                         pp.parse_legacy_blend('mountain man:3 man mountain:1'))
+                         pp.parse_legacy_blend('mountain man:3 man mountain:1', skip_normalize=False))
 
         self.assertEqual(Blend([FlattenedPrompt([('mountain man', 1)]),
                                 FlattenedPrompt([('man mountain', 1)])],
                                 weights=[1.0,0.0]),
-                         pp.parse_legacy_blend('mountain man:3 man mountain:0'))
+                         pp.parse_legacy_blend('mountain man:3 man mountain:0', skip_normalize=False))
 
         self.assertEqual(Blend([FlattenedPrompt([('mountain man', 1)]),
                                 FlattenedPrompt([('man mountain', 1)])],
                                 weights=[0.8,0.2]),
-                         pp.parse_legacy_blend('"mountain man":4 man mountain'))
+                         pp.parse_legacy_blend('"mountain man":4 man mountain', skip_normalize=False))
 
 
     def test_single(self):


### PR DESCRIPTION
test-invoke-pip:
- add workflow_dispatch to enable manual execution
- disable windows-cuda since the 2GB pip packages just work sometimes
- add macos-nightly but disable for now
- set PIP_USE_PEP517 to enable it in all pip related steps
- enable caching pip packages in setup-python action
- add installation of optional test dependencies
- add pytest step
- set INVOKE_OUTDIR and huggingface-cache-dir via python commands
- fix huggingface-models cache and load after pytests succeeded
- remove `--full-precision` since detected automatically
  - if there would come gpu runners available they would be used ootb
- rename step `Run the tests` to `run invoke`
- set runner specific outdir in `run invoke`
- fix Archive results step and also combine all results into one archive

.gitignore:
- add `configs/models.yaml.orig`
- add `junit/`